### PR TITLE
Problem appears to be with Duration#shiftTo

### DIFF
--- a/src/duration.js
+++ b/src/duration.js
@@ -420,6 +420,8 @@ export default class Duration {
       ...opts,
       floor: opts.round !== false && opts.floor !== false,
     };
+
+    console.log("this", this);
     return this.isValid
       ? Formatter.create(this.loc, fmtOpts).formatDurationFromString(this, fmt)
       : INVALID;
@@ -714,6 +716,10 @@ export default class Duration {
         accumulated[k] = vals[k];
       }
     }
+
+    // For hour: 2.4 test case --
+    //    accumulated { hours: 0, minutes: 0.9999999999999929 }
+    console.log("accumulated", accumulated);
 
     // anything leftover becomes the decimal for the last unit
     // lastUnit must be defined since units is not empty

--- a/src/impl/formatter.js
+++ b/src/impl/formatter.js
@@ -385,6 +385,20 @@ export default class Formatter {
         []
       ),
       collapsed = dur.shiftTo(...realTokens.map(tokenToField).filter((t) => t));
+
+    // dur: Duration {
+    //   values: { hours: 2.4 },
+    // ...
+    console.log("dur", dur);
+
+    // realTokens: [ 'hh', ':', 'mm' ]
+    console.log("realTokens", realTokens);
+
+    // collapsed: Duration {
+    //   values: { hours: 2, minutes: 23.999999999999993 },
+    // ...
+    console.log("collapsed", collapsed);
+
     return stringifyTokens(tokens, tokenToString(collapsed));
   }
 }

--- a/test/datetime/toFormat.test.js
+++ b/test/datetime/toFormat.test.js
@@ -22,6 +22,12 @@ const dt = DateTime.fromObject(
 // #toFormat()
 //------
 
+test.only("toFormat from hours", () => {
+  console.log("dt.set", dt.set({ hour: 2.4 }));
+  expect(dt.set({ hour: 2.4 }));
+  expect(dt.set({ hour: 2.4 }).toFormat("hh:mm")).toBe("02:24");
+});
+
 test("DateTime#toFormat accepts the locale from the DateTime or the options", () => {
   expect(dt.setLocale("fr").toFormat("LLLL")).toBe("mai");
   expect(dt.toFormat("LLLL", { locale: "fr" })).toBe("mai");

--- a/test/duration/format.test.js
+++ b/test/duration/format.test.js
@@ -35,6 +35,11 @@ test("Duration#toISO fills out every field with fractional", () => {
   expect(dur.toISO()).toBe("P1.1Y2.2M1.1W3.3DT4.4H5.5M6.607S");
 });
 
+test.only("Duration#toISO creates a minimal string", () => {
+  console.log("Duration", Duration.fromObject({ hour: 2.4 }).values);
+  expect(Duration.fromObject({ hour: 2.4 }).toFormat("hh:mm")).toBe("2:24");
+});
+
 test("Duration#toISO creates a minimal string", () => {
   expect(Duration.fromObject({ years: 3, seconds: 45 }).toISO()).toBe("P3YT45S");
   expect(Duration.fromObject({ months: 4, seconds: 45 }).toISO()).toBe("P4MT45S");

--- a/test/duration/units.test.js
+++ b/test/duration/units.test.js
@@ -17,6 +17,11 @@ test("Duration#shiftTo boils hours down milliseconds", () => {
   expect(dur.milliseconds).toBe(3600000);
 });
 
+test.only("Duration#shiftTo hours with decimal", () => {
+  const dur = Duration.fromObject({ hours: 2.4 }).shiftTo("hour", "minute");
+  expect(dur.values).toBe({ hours: 2, minutes: 24 });
+});
+
 test("Duration boils hours down shiftTo minutes and milliseconds", () => {
   const dur = Duration.fromObject({ hours: 1, seconds: 30 }).shiftTo("minutes", "milliseconds");
   expect(dur.toObject()).toEqual({ minutes: 60, milliseconds: 30000 });


### PR DESCRIPTION
Added the following tests for the issue:
 - Duration#shiftTo hours with decimal
   test/duration/units.test.js
   npm run jest test/duration/units.test.js

 - Duration#toFormat handles decimal
   test/duration/format.test.js
   npm run jest test/duration/format.test.js

There are a few consol.logs that show were .4 hours is being
converted to 23.999999999999993 minutes in the shiftTo funciton.
There is a for loop in there that iterates over the orderedUnits
(year, month, day, etc.). At the end of that loop the acc contains
{ minutes: 0.9999999999999929 }